### PR TITLE
Swap! should return local values - REPL friendly printer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.2.0
+
+- Cursor arguments swapped.
+```clj
+;; before
+(cursor [:path :to :data] atom)
+
+;; now
+(cursor atom [:path :to :data])

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 reagent-cursor
 ==============
 
-Optional cursors library for Reagent.
+Cursors library for clojurescript atoms.
 
 Usage
 -----
 
-Add `[reagent/reagent-cursor "0.1.1"]` to `:dependencies` in `project.clj`.
+Add `[reagent/reagent-cursor "0.2.0"]` to `:dependencies` in `project.clj`.
 
-In your Reagent application, `(:require [reagent.cursor :as rc])` and then construct cursors from Reagent atoms like this `(rc/cursor [:path :to :data] ratom)`.
+In your Reagent application, `(:require [reagent.cursor :as rc])` and then construct cursors from Reagent atoms like this `(rc/cursor ratom [:path :to :data])`.
 
 See docstrings in `reagent.cursor` for more details.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject reagent/reagent-cursor "0.1.1"
+(defproject reagent/reagent-cursor "0.2.0"
   :description "Provide Om-inspired cursors for Reagent"
   :url "http://github.com/reagent-project/reagent-cursor"
   :license {:name "Eclipse Public License"

--- a/src/reagent/cursor.cljs
+++ b/src/reagent/cursor.cljs
@@ -5,7 +5,7 @@
 
   (:require [reagent.cursor :as rc])
 
-  (rc/cursor [:path :to :some :item] some-ratom)
+  (rc/cursor some-ratom [:path :to :some :item])
 
   The cursor behaves in all ways like a regular Reagent atom except
   that it dereferences to the specified path inside the atom
@@ -20,7 +20,7 @@
 (defprotocol IPath
   (-path [c]))
 
-(deftype RCursor [path ratom]
+(deftype RCursor [ratom path]
   IAtom
 
   IRoot
@@ -89,34 +89,33 @@
 
 (defn root
   "Return the original atom of a cursor."
-  [cursor]
-  (-root cursor))
+  [c]
+  (-root c))
 
 (defn path
   "Return the cursor's path."
-  [cursor]
-  (-path cursor))
+  [c]
+  (-path c))
 
 (declare cursor)
 (defn parent
   "Return a cursor one level higher in the path, or the root atom
-  itself. Should probably only be used as a debugging tool only to
-  keep cursor code architecture-agnostic." [c]
+  itself. Should probably be used as a debugging tool only to keep
+  cursor code architecture-agnostic." [c]
   (cond
    (instance? Atom c) c
    (not (next (path c))) (root c)
-   :else (cursor (drop-last (path c)) (root c))))
+   :else (cursor (root c) (drop-last (path c)))))
 
 
 (defn cursor
-  "Provide a cursor into a Reagent atom.
+  "Provide a cursor into an atom.
 
-Behaves like a Reagent atom but focuses updates and derefs to
-the specified path within the wrapped Reagent atom. e.g.,
+  Behaves like a normal atom but focuses updates and derefs to
+  the specified path within the wrapped atom. e.g.,
   (let [c (cursor [:nested :content] ra)]
-    ... @c ;; equivalent to (get-in @ra [:nested :content])
-    ... (reset! c 42) ;; equivalent to (swap! ra assoc-in [:nested :content] 42)
-    ... (swap! c inc) ;; equivalence to (swap! ra update-in [:nested :content] inc)
-    )"
-  ([path] (fn [ra] (cursor path ra)))
-  ([path ra] (RCursor. path ra)))
+  ... @c ;; equivalent to (get-in @ra [:nested :content])
+  ... (reset! c 42) ;; equivalent to (swap! ra assoc-in [:nested :content] 42)
+  ... (swap! c inc) ;; equivalence to (swap! ra update-in [:nested :content] inc)
+  )"
+  [ra path] (RCursor. ra path))


### PR DESCRIPTION
The first modification is to make `swap!` behave like its description.

> (...) Returns the value that was swapped in.

Cursors now act like normal atoms.

Second modification is a REPL friendly printer until a more thorough reader/printer scheme is decided.
(When I print a cursor, I don't want to see the entire app-state atom printed.)
