### PR TITLE
If the path is empty, return the atom instead of a cursor.

### DIFF
--- a/src/reagent/cursor.cljs
+++ b/src/reagent/cursor.cljs
@@ -106,4 +106,4 @@
 
   Behaves like a normal atom for the value at the specified path."
   [a path]
-  (cursor path ))
+  (cursor path a))

--- a/src/reagent/cursor.cljs
+++ b/src/reagent/cursor.cljs
@@ -94,8 +94,11 @@
   ... (reset! c 42) ;; equivalent to (swap! ra assoc-in [:nested :content] 42)
   ... (swap! c inc) ;; equivalence to (swap! ra update-in [:nested :content] inc)
   )"
-  ([path] (fn [ra] (cursor path ra)))
-  ([path ra] (RCursor. path ra)))
+  ([path] (fn [a] (cursor path a)))
+  ([path a]
+   (if (seq path)
+     (RCursor. path a)
+     a)))
 
 
 (defn cur
@@ -103,4 +106,4 @@
 
   Behaves like a normal atom for the value at the specified path."
   [a path]
-  (RCursor. path a))
+  (cursor path ))

--- a/test/cursor_impl.cljs
+++ b/test/cursor_impl.cljs
@@ -9,22 +9,36 @@
 
 (deftest values
   (let [test-atom (atom {:a {:b {:c {:d 1}}}})
-        test-cursor (c/cur test-atom [:a :b :c :d])]
+        test-cursor (c/cur test-atom [:a :b :c :d])
+        test-cursor2 (c/cur test-atom [])] ;; nasty edge case
 
     ;; get the initial values
     (is (= (get-in @test-atom [:a :b :c :d])
            @test-cursor))
+
+    (is (= get-in @test-atom []
+           @test-cursor2))
     
     ;; now we update the cursor with a reset    
     (reset! test-cursor 2)
     (is (= @test-cursor 2))
     (is (= (get-in @test-atom [:a :b :c :d]) 2))
 
+    (reset! test-cursor2 2)
+    (is (= @test-cursor2 2))
+    (is (= (get-in @test-atom []) 2))
+
     ;; swap
     (reset! test-cursor {}) ;; empty map
     (swap! test-cursor assoc :z 3)
     (is (= @test-cursor {:z 3}))
     (is (= (get-in @test-atom [:a :b :c :d])
+           {:z 3}))
+
+    (reset! test-cursor2 {}) ;; empty map
+    (swap! test-cursor2 assoc :z 3)
+    (is (= @test-cursor2 {:z 3}))
+    (is (= (get-in @test-atom [])
            {:z 3}))))
 
 

--- a/test/cursor_impl.cljs
+++ b/test/cursor_impl.cljs
@@ -12,21 +12,24 @@
         test-cursor (c/cur test-atom [:a :b :c :d])
         test-cursor2 (c/cur test-atom [])] ;; nasty edge case
 
+    (is (= cljs.core/Atom (type test-cursor2)))
+    
     ;; get the initial values
     (is (= (get-in @test-atom [:a :b :c :d])
            @test-cursor))
 
-    (is (= get-in @test-atom []
+    (is (= (get-in @test-atom [])
            @test-cursor2))
     
     ;; now we update the cursor with a reset    
     (reset! test-cursor 2)
     (is (= @test-cursor 2))
-    (is (= (get-in @test-atom [:a :b :c :d]) 2))
-
-    (reset! test-cursor2 2)
-    (is (= @test-cursor2 2))
-    (is (= (get-in @test-atom []) 2))
+    (is (= (get-in @test-atom [:a :b :c :d]) 2))    
+   
+    (reset! test-cursor2 3)
+    (is (= @test-cursor2 3))
+    (is (= @test-atom 3))
+    (reset! test-atom {:a {:b {:c {:d 1}}}}) ;; restore test-atom
 
     ;; swap
     (reset! test-cursor {}) ;; empty map


### PR DESCRIPTION
Empty paths (`[ ]`) are problematic with functions like `update-in`.

To avoid any problem, simply return the original atom if someone tries to create a cursor with an empty path.
